### PR TITLE
Adding port to db connection string

### DIFF
--- a/man/osmdbt.md
+++ b/man/osmdbt.md
@@ -41,6 +41,7 @@ default is `osmdbt_config.yaml` in the current directory.
 The config file contains the following settings:
 
 * database.host: Name of the host running the database (default: `localhost`)
+* database.port: TCP port to connect to (default: 5432)
 * database.dbname: Name of the database (default: `osm`)
 * database.user: Database user (default: `osm`)
 * database.password: Password of database user (default: `osm`)

--- a/osmdbt_config.yaml
+++ b/osmdbt_config.yaml
@@ -1,6 +1,7 @@
 ---
 database:
     host: localhost
+    port: 5432
     dbname: osm
     user: osm
     password: osm

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -16,6 +16,9 @@ Config::Config(Options const &options, osmium::VerboseOutput &vout)
     if (m_config["database"]["host"]) {
         m_db_host = m_config["database"]["host"].as<std::string>();
     }
+    if (m_config["database"]["port"]) {
+        m_db_port = m_config["database"]["port"].as<std::string>();
+    }
     if (m_config["database"]["dbname"]) {
         m_db_dbname = m_config["database"]["dbname"].as<std::string>();
     }
@@ -27,6 +30,8 @@ Config::Config(Options const &options, osmium::VerboseOutput &vout)
     }
 
     m_db_connection += m_db_host;
+    m_db_connection += " port=";
+    m_db_connection += m_db_port;
     m_db_connection += " dbname=";
     m_db_connection += m_db_dbname;
     m_db_connection += " user=";
@@ -54,6 +59,7 @@ Config::Config(Options const &options, osmium::VerboseOutput &vout)
     vout << "Config:\n";
     vout << "  Database:\n";
     vout << "    Host: " << m_db_host << '\n';
+    vout << "    Port: " << m_db_port << '\n';
     vout << "    Name: " << m_db_dbname << '\n';
     vout << "    User: " << m_db_user << '\n';
     vout << "    Password: (not shown)\n";

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -14,6 +14,7 @@ class Config
     YAML::Node m_config;
 
     std::string m_db_host{"localhost"};
+    std::string m_db_port{"5432"};
     std::string m_db_dbname{"osm"};
     std::string m_db_user{"osm"};
     std::string m_db_password{"osm"};


### PR DESCRIPTION
I defined the new port parameter as string, I hope that's ok. The port number also might double as name extension for domain socket connections according to https://www.postgresql.org/docs/9.5/libpq-connect.html, but that would also be a number:

```
    host: /var/run/postgresql
    port: 5432
```

Closes #1 
