### PR TITLE
Use read only transactions where applicable (take 2)

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <string>
 
-std::string get_db_version(pqxx::work &txn)
+std::string get_db_version(pqxx::dbtransaction &txn)
 {
     pqxx::result const result = txn.exec("SELECT * FROM version();");
     if (result.size() != 1) {
@@ -20,7 +20,7 @@ std::string get_db_version(pqxx::work &txn)
     return row[0].as<std::string>();
 }
 
-int get_db_major_version(pqxx::work &txn)
+int get_db_major_version(pqxx::dbtransaction &txn)
 {
     pqxx::result const result = txn.exec("SHOW server_version_num;");
     if (result.size() != 1) {
@@ -32,7 +32,7 @@ int get_db_major_version(pqxx::work &txn)
     return row[0].as<int>() / 10000;
 }
 
-void catchup_to_lsn(pqxx::work &txn, std::string const &replication_slot,
+void catchup_to_lsn(pqxx::dbtransaction &txn, std::string const &replication_slot,
                     lsn_type lsn)
 {
 

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -6,8 +6,8 @@
 
 #include <string>
 
-std::string get_db_version(pqxx::work &txn);
-int get_db_major_version(pqxx::work &txn);
+std::string get_db_version(pqxx::dbtransaction &txn);
+int get_db_major_version(pqxx::dbtransaction &txn);
 
-void catchup_to_lsn(pqxx::work &txn, std::string const &replication_slot,
+void catchup_to_lsn(pqxx::dbtransaction &txn, std::string const &replication_slot,
                     lsn_type lsn);

--- a/src/osmdbt-create-diff.cpp
+++ b/src/osmdbt-create-diff.cpp
@@ -82,7 +82,7 @@ private:
     bool m_dry_run = false;
 }; // class CreateDiffOptions
 
-static void populate_changeset_cache(pqxx::work &txn,
+static void populate_changeset_cache(pqxx::dbtransaction &txn,
                                      changeset_user_lookup &cucache)
 {
     for (auto &c : cucache) {
@@ -220,7 +220,7 @@ bool app(osmium::VerboseOutput &vout, Config const &config,
         "SELECT member_type, member_id, member_role FROM relation_members "
         "WHERE relation_id=$1 AND version=$2 ORDER BY sequence_id");
 
-    pqxx::work txn{db};
+    pqxx::read_transaction txn{db};
     vout << "Database version: " << get_db_version(txn) << '\n';
 
     std::vector<osmobj> objects_todo;
@@ -330,7 +330,6 @@ bool app(osmium::VerboseOutput &vout, Config const &config,
     }
 
     vout << "All done.\n";
-    txn.commit();
 
     vout << "Done.\n";
 

--- a/src/osmdbt-fake-log.cpp
+++ b/src/osmdbt-fake-log.cpp
@@ -72,7 +72,7 @@ private:
 }; // class FakeLogOptions
 
 static std::size_t
-read_objects(pqxx::work &txn, std::string &data, osmium::Timestamp timestamp,
+read_objects(pqxx::dbtransaction &txn, std::string &data, osmium::Timestamp timestamp,
              osmium::item_type type,
              osmium::nwr_array<std::set<id_version_type>> const &objects_done)
 {
@@ -149,7 +149,7 @@ bool app(osmium::VerboseOutput &vout, Config const &config,
                "SELECT relation_id, version, changeset_id FROM relations WHERE "
                "\"timestamp\" >= $1 ORDER BY relation_id, version;");
 
-    pqxx::work txn{db};
+    pqxx::read_transaction txn{db};
     vout << "Database version: " << get_db_version(txn) << '\n';
 
     vout << "Reading changes...\n";

--- a/src/osmdbt-testdb.cpp
+++ b/src/osmdbt-testdb.cpp
@@ -13,7 +13,7 @@ bool app(osmium::VerboseOutput &vout, Config const &config,
     vout << "Connecting to database...\n";
     pqxx::connection db{config.db_connection()};
 
-    pqxx::work txn{db};
+    pqxx::read_transaction txn{db};
 
     int const db_version = get_db_major_version(txn);
     vout << "Database version: " << db_version << " [" << get_db_version(txn)

--- a/src/osmobj.cpp
+++ b/src/osmobj.cpp
@@ -45,7 +45,7 @@ osmobj::osmobj(std::string const &obj, std::string const &version,
     }
 }
 
-void osmobj::get_data(pqxx::work &txn, osmium::memory::Buffer &buffer,
+void osmobj::get_data(pqxx::dbtransaction &txn, osmium::memory::Buffer &buffer,
                       changeset_user_lookup const &cucache) const
 {
     pqxx::result const result =
@@ -103,7 +103,7 @@ void osmobj::get_data(pqxx::work &txn, osmium::memory::Buffer &buffer,
     buffer.commit();
 }
 
-void osmobj::add_nodes(pqxx::work &txn,
+void osmobj::add_nodes(pqxx::dbtransaction &txn,
                        osmium::builder::WayBuilder &builder) const
 {
     osmium::builder::WayNodeListBuilder wnbuilder{builder};
@@ -119,7 +119,7 @@ void osmobj::add_nodes(pqxx::work &txn,
     }
 }
 
-void osmobj::add_members(pqxx::work &txn,
+void osmobj::add_members(pqxx::dbtransaction &txn,
                          osmium::builder::RelationBuilder &builder) const
 {
     osmium::builder::RelationMemberListBuilder mbuilder{builder};

--- a/src/osmobj.hpp
+++ b/src/osmobj.hpp
@@ -32,10 +32,10 @@ public:
     osmium::object_version_type version() const noexcept { return m_version; }
     osmium::changeset_id_type cid() const noexcept { return m_cid; }
 
-    void add_nodes(pqxx::work &txn, osmium::builder::WayBuilder &builder) const;
-    void add_members(pqxx::work &txn,
+    void add_nodes(pqxx::dbtransaction &txn, osmium::builder::WayBuilder &builder) const;
+    void add_members(pqxx::dbtransaction &txn,
                      osmium::builder::RelationBuilder &builder) const;
-    void get_data(pqxx::work &txn, osmium::memory::Buffer &buffer,
+    void get_data(pqxx::dbtransaction &txn, osmium::memory::Buffer &buffer,
                   changeset_user_lookup const &cucache) const;
 
     template <typename TBuilder>
@@ -52,7 +52,7 @@ public:
     }
 
     template <typename TBuilder>
-    void add_tags(pqxx::work &txn, TBuilder &builder) const
+    void add_tags(pqxx::dbtransaction &txn, TBuilder &builder) const
     {
         osmium::builder::TagListBuilder tbuilder{builder};
         pqxx::result const result =


### PR DESCRIPTION
(Second try of #22, now with dbtransaction as base class)

In most cases, we don't want to change any data on the database. This PR makes this more explicit by using a read_transaction. Elsewhere this is referred to as best practice and additional security layer.

Under the hood libpqxx will start a new transaction with "BEGIN READ ONLY" instead of "BEGIN". Curiously, catchup_to_lsn would also work on a read-only txns (probably because it's a SELECT statement). but for the sake of clarity, I decided to use a read write transaction in this case. This adds a bit of clutter to get-log, which is why I split up this PR into many small commits for easier review&cherry picking.