### PR TITLE
Fixed GitHub Actions

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -1,35 +1,35 @@
-name: 'Build and test osmdbt'
+---
+name: Build and test osmdbt
 
 runs:
-    using: "composite"
+  using: composite
 
-    steps:
-      - name: create build directory
-        run: mkdir build
-        shell: bash
+  steps:
+    - name: create build directory
+      run: mkdir build
+      shell: bash
 
-      - name: configure
-        run: |
-          cmake -LA -DCMAKE_BUILD_TYPE=Debug \
-                -DPG_CONFIG=/usr/lib/postgresql/$PG_VERSION/bin/pg_config \
-                -DPG_VIRTUALENV_VERSION=-v$PG_VERSION \
-                -DOSMIUM_INCLUDE_DIR=../../libosmium/include \
-                -DPROTOZERO_INCLUDE_DIR=../../protozero/include \
-                ..
-        shell: bash
-        working-directory: build
-        env:
-          CXXFLAGS: -pedantic -Wextra -Werror
+    - name: configure
+      run: |
+        cmake -LA -DCMAKE_BUILD_TYPE=Debug \
+          -DPG_CONFIG=/usr/lib/postgresql/$PG_VERSION/bin/pg_config \
+          -DPG_VIRTUALENV_VERSION=-v$PG_VERSION \
+          -DOSMIUM_INCLUDE_DIR=../../libosmium/include \
+          -DPROTOZERO_INCLUDE_DIR=../../protozero/include \
+          ..
+      shell: bash
+      working-directory: build
+      env:
+        CXXFLAGS: -pedantic -Wextra -Werror
 
-      - name: build
-        run: make VERBOSE=1
-        shell: bash
-        working-directory: build
+    - name: build
+      run: make VERBOSE=1
+      shell: bash
+      working-directory: build
 
-      - name: test
-        run: |
-          sudo make install
-          ctest --output-on-failure
-        shell: bash
-        working-directory: build
-
+    - name: test
+      run: |
+        make install
+        ctest --output-on-failure
+      shell: bash
+      working-directory: build

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,29 +1,62 @@
-name: 'Install Prerequisites'
+---
+name: Install Prerequisites
+
+inputs:
+  compiler_packages:
+    description: Compiler package(s) to install
+    required: true
+  pg_version:
+    description: PostgreSQL package version to install
+    required: true
 
 runs:
-  using: "composite"
+  using: composite
 
   steps:
-    - name: Install packages
+    - name: Install build dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -yq \
-            libboost-filesystem-dev \
-            libboost-program-options-dev \
-            libyaml-cpp-dev \
-            libpqxx-dev \
-            pandoc \
-            postgresql-10 \
-            postgresql-server-dev-10 \
-            postgresql-11 \
-            postgresql-server-dev-11 \
-            postgresql-12 \
-            postgresql-server-dev-12 \
-            postgresql-server-dev-all
-      shell: bash
+        apt-get --quiet --quiet update
+        apt-get --quiet --quiet install \
+          ${{ inputs.compiler_packages }} \
+          build-essential \
+          cmake \
+          curl \
+          gettext-base \
+          git \
+          gnupg \
+          libboost-filesystem-dev \
+          libboost-program-options-dev \
+          libbz2-dev \
+          libexpat1-dev \
+          libpqxx-dev \
+          libyaml-cpp-dev \
+          pandoc \
+          postgresql-common \
+          zlib1g-dev
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install and configure PGDG repository
+      run: |
+        echo | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install PostgreSQL dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get --quiet --quiet update
+        apt-get --quiet --quiet install \
+          postgresql-${{ inputs.pg_version }} \
+          postgresql-server-dev-${{ inputs.pg_version }} \
+          postgresql-server-dev-all
+      shell: bash --noprofile --norc -euxo pipefail {0}
 
     - name: Install libosmium and protozero from git
       run: |
-        git clone --quiet --depth 1 https://github.com/osmcode/libosmium.git ../libosmium
-        git clone --quiet --depth 1 https://github.com/mapbox/protozero.git ../protozero
-      shell: bash
+        git clone --quiet --depth 1 https://github.com/osmcode/libosmium.git \
+          ../libosmium
+        git clone --quiet --depth 1 https://github.com/mapbox/protozero.git \
+          ../protozero
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,110 +1,87 @@
+---
 name: CI
 
-on: [ push, pull_request ]
+on:
+  - pull_request
+  - push
 
 jobs:
-
-  ubuntu-bionic-pg10:
-    runs-on: ubuntu-18.04
-
-    env:
-      CC: gcc-7
-      CXX: g++-7
-      PG_VERSION: 10
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu-bionic-pg11:
-    runs-on: ubuntu-18.04
-
-    env:
-      CC: gcc-7
-      CXX: g++-7
-      PG_VERSION: 11
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu-bionic-pg12:
-    runs-on: ubuntu-18.04
+  build-and-test-clang:
+    name: ubuntu-${{ matrix.ubuntu_version }}-pg${{ matrix.pg_version }}-clang-${{ matrix.compiler_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler_version:
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+        pg_version:
+          - 10
+          - 11
+          - 13
+        ubuntu_version:
+          - 18.04
+          - 20.04
+        exclude:
+          - compiler_version: 11
+            ubuntu_version: 18.04
+          - compiler_version: 12
+            ubuntu_version: 18.04
+      fail-fast: false
 
     env:
-      CC: gcc-7
-      CXX: g++-7
-      PG_VERSION: 12
-
+      CC: clang-${{ matrix.compiler_version }}
+      CXX: clang++-${{ matrix.compiler_version }}
+      PG_VERSION: ${{ matrix.pg_version }}
+    container:
+      image: ubuntu:${{ matrix.ubuntu_version }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
+      - name: Install Dependencies
+        uses: ./.github/actions/install
+        with:
+          compiler_packages: clang-${{ matrix.compiler_version }}
+          pg_version: ${{ matrix.pg_version }}
       - uses: ./.github/actions/build-and-test
 
-  ubuntu-focal-pg10:
-    runs-on: ubuntu-20.04
+  build-and-test-gcc:
+    name: ubuntu-${{ matrix.ubuntu_version }}-pg${{ matrix.pg_version }}-gcc-${{ matrix.compiler_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler_version:
+          - 7
+          - 8
+          - 9
+          - 10
+        pg_version:
+          - 10
+          - 11
+          - 13
+        ubuntu_version:
+          - 18.04
+          - 20.04
+        exclude:
+          - compiler_version: 9
+            ubuntu_version: 18.04
+          - compiler_version: 10
+            ubuntu_version: 18.04
+      fail-fast: false
 
     env:
-      CC: gcc-9
-      CXX: g++-9
-      PG_VERSION: 10
-
+      CC: gcc-${{ matrix.compiler_version }}
+      CXX: g++-${{ matrix.compiler_version }}
+      PG_VERSION: ${{ matrix.pg_version }}
+    container:
+      image: ubuntu:${{ matrix.ubuntu_version }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
+      - name: Install Dependencies
+        uses: ./.github/actions/install
+        with:
+          compiler_packages: gcc-${{ matrix.compiler_version }} g++-${{ matrix.compiler_version }}
+          pg_version: ${{ matrix.pg_version }}
       - uses: ./.github/actions/build-and-test
-
-  ubuntu-focal-pg11:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-9
-      CXX: g++-9
-      PG_VERSION: 11
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu-focal-pg12:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-9
-      CXX: g++-9
-      PG_VERSION: 12
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu-focal-pg13:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-9
-      CXX: g++-9
-      PG_VERSION: 13
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu-focal-pg12-clang:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: clang-10
-      CXX: clang++-10
-      PG_VERSION: 12
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/install
-      - uses: ./.github/actions/build-and-test
-


### PR DESCRIPTION
By no longer using GitHub's images in favor of using static tagged images from Docker Hub.

**Also:**
* Added testing of many more combinations of Clang/GCC/PostgreSQL/Ubuntu versions
  * Feel free to remove any `compiler_version`/`pg_version` values if it seems like too much
* Fixed various `yamllint` warnings under `.github/`

Addresses #34

See [here](https://github.com/hummeltech/osmdbt/actions/runs/1574839611) for an example of a passing workflow run.