### PR TITLE
Fix generated PBF file to be `HistoricalInformation`

### DIFF
--- a/src/osmdbt-create-diff.cpp
+++ b/src/osmdbt-create-diff.cpp
@@ -650,7 +650,7 @@ bool app(osmium::VerboseOutput &vout, Config const &config,
     vout << "Opening output file '" << new_change_file_name << ".pbf'...\n";
 
     osmium::io::Header header;
-    header.has_multiple_object_versions();
+    header.set_has_multiple_object_versions(true);
     header.set("generator", "osmdbt-create-diff/" + get_osmdbt_version());
 
     osmium::io::Writer writer_xml{new_change_file_name + ".gz", header,


### PR DESCRIPTION
I would like to see PBF on https://planet.openstreetmap.org/replication/ :)
I used one of planet/replication/daily from [Fri Oct 20 00:18:58 UTC 2023](https://osm-planet-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com/planet/replication/day/000/004/055.state.txt) as test:

|Info|pbf|osc.gz|
|----|---|----|
|Size|54M|117M|
|osmium fileinfo -e|1.1s|12.8s|