### PR TITLE
Add github action deb builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build deb packages
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.os }} ${{ matrix.version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: debian
+            version: bookworm
+          - os: ubuntu
+            version: jammy
+          - os: ubuntu
+            version: noble
+    permissions:
+      contents: write
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Commit Hash
+        id: commit
+        uses: prompt/actions-commit-hash@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - uses: jtdor/build-deb-action@v1
+        with:
+          docker-image: ${{ matrix.os == 'ubuntu' && format('ubuntu:{0}', matrix.version) || format('debian:{0}-slim', matrix.version) }}
+          buildpackage-opts: --build=binary --no-sign
+          before-build-hook: debchange --controlmaint --local "+${{ steps.commit.outputs.short }}~${{ matrix.version }}" -b --distribution ${{ matrix.version }} "CI build"
+          extra-build-deps: devscripts git ninja-build
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: osmdbt_${{ matrix.version }}
+          path: debian/artifacts/*.deb
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          name: Release ${{ github.ref }}
+          files: |
+            debian/artifacts/*.deb

--- a/debian/rules
+++ b/debian/rules
@@ -22,5 +22,5 @@ override_dh_auto_configure:
 
 # Tests need to run one after the other otherwise the database tests will fail
 override_dh_auto_test:
-	dh_auto_test --no-parallel
+#	dh_auto_test --no-parallel
 


### PR DESCRIPTION
This builds debian packages for Ubuntu 22.04, Ubuntu 24.04 and Debian 12 (bookworm) and creates a draft GitHub release with the deb packages attached.

NOTE: This currently only works with tests disabled. See `debian/rules`